### PR TITLE
feat: add onHotReloadLog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.0
+
+- Add `onHotReloadLog` and `logLevel` parameters
+
 ## 1.2.0
 
 - Added callbacks for custom logging output.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ withHotreload(
   onReloaded: () => myLogger.log('Reload!'),
   onHotReloadNotAvailable: () => myLogger.log('No hot-reload :('),
   onHotReloadAvailable: () => myLogger.log('Yay! Hot-reload :)'),
+  onHotReloadLog: (log) => myLogger.log('Reload Log: ${log.message}'),
+  logLevel: Level.INFO,
 );
 ```
 

--- a/lib/shelf_hotreload.dart
+++ b/lib/shelf_hotreload.dart
@@ -2,4 +2,4 @@
 library shelf_hotreload;
 
 export 'src/with_hotreload.dart';
-
+export 'package:logging/logging.dart' show Level, LogRecord;

--- a/lib/src/with_hotreload.dart
+++ b/lib/src/with_hotreload.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 
 import 'package:hotreloader/hotreloader.dart';
 import 'package:intl/intl.dart';
+import 'package:logging/logging.dart' as logging;
 
 /// Provides hot-reloading ability to code that providers an http server.
 ///
@@ -24,10 +25,17 @@ void withHotreload(
   /// If not set, it will `print()` a default message.
   FutureOr<void> Function()? onHotReloadAvailable,
 
-  /// Called once if hot-reload is not available (ee.g. no VM service available)
+  /// Called once if hot-reload is not available (e.g. no VM service available)
   ///
   /// If not set, it will `print()` a default message.
   FutureOr<void> Function()? onHotReloadNotAvailable,
+
+  /// Called every time a hot reload log is recorded.
+  FutureOr<void> Function(logging.LogRecord log)? onHotReloadLog,
+
+  /// The log level to use when calling `onHotReloadLog`.
+  /// By default logging is turned off.
+  logging.Level logLevel = logging.Level.OFF,
 }) async {
   /// Current server instance
   HttpServer? runningServer;
@@ -35,15 +43,27 @@ void withHotreload(
   /// Set default messages
   onReloaded ??= () {
     final time = DateFormat.Hms().format(DateTime.now());
-    print('[hotreload] $time - Application reloaded.');
+    stdout.writeln('[hotreload] $time - Application reloaded.');
   };
   onHotReloadAvailable ??= () {
-    print('[hotreload] Hot reload is enabled.');
+    stdout.writeln('[hotreload] Hot reload is enabled.');
   };
   onHotReloadNotAvailable ??= () {
-    print(
-        '[hotreload] Hot reload not enabled. Run this app with --enable-vm-service (or use debug run) in order to enable hot reload.');
+    stdout.writeln(
+      '[hotreload] Hot reload not enabled. Run this app with --enable-vm-service (or use debug run) in order to enable hot reload.',
+    );
   };
+  onHotReloadLog ??= (log) {
+    final time = DateFormat.Hms().format(log.time);
+    (log.level < logging.Level.SEVERE ? stdout : stderr).writeln(
+      '[hotreload] $time - ${log.message}',
+    );
+  };
+
+  /// Configure logging
+  HotReloader.logLevel = logLevel;
+  logging.hierarchicalLoggingEnabled = true;
+  logging.Logger.root.onRecord.listen(onHotReloadLog);
 
   /// Function in charge of replacing the running http server
   final obtainNewServer = (FutureOr<HttpServer> Function() create) async {

--- a/lib/src/with_hotreload.dart
+++ b/lib/src/with_hotreload.dart
@@ -61,8 +61,8 @@ void withHotreload(
   };
 
   /// Configure logging
-  HotReloader.logLevel = logLevel;
   logging.hierarchicalLoggingEnabled = true;
+  HotReloader.logLevel = logLevel;
   logging.Logger.root.onRecord.listen(onHotReloadLog);
 
   /// Function in charge of replacing the running http server

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: shelf_hotreload
 description: Wrapper to easily enable hot-reload for shelf applications.
-version: 1.2.0
+version: 1.3.0
 repository: https://github.com/felixblaschke/shelf_hotreload
 
 environment:
@@ -9,6 +9,7 @@ environment:
 dependencies:
   hotreloader: ^3.0.4
   intl: ^0.17.0
+  logging: ^1.0.2
 
 dev_dependencies:
   lints: ^2.0.0


### PR DESCRIPTION
## Description

As a developer, I want to be able to access any/all logs from the hotreloader so that I can fully customize the user facing logging experience. One use case is surfacing hotReload errors to users which is currently not possible.

This pull request adds an optional `onHotReloadLog` and a `logLevel` parameter which enable developers to configure the log level and intercept/handle any logs from the underlying hotreloader.

### Example Usage

```dart
final myLogger = Logger();

withHotreload(
  () => createServer(),
  onReloaded: () => myLogger.log('Reload!'),
  onHotReloadNotAvailable: () => myLogger.log('No hot-reload :('),
  onHotReloadAvailable: () => myLogger.log('Yay! Hot-reload :)'),
  onHotReloadLog: (log) => myLogger.log('Reload Log: ${log.message}'),
  logLevel: Level.INFO,
);
```